### PR TITLE
[Bug Fix]: can't format an Astro file with a `<!DOCTYPE html>` + embedded JSX expressions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -193,7 +193,7 @@ const print = (path, opts, print) => {
             return attribute;
           });
 
-          return group(['<', node.name.toUpperCase(), ...attributesWithLowercaseHTML, , `>`]);
+          return group(['<', node.name.toUpperCase(), ...attributesWithLowercaseHTML, `>`]);
         }
       } catch (e) {
         console.warn(`error ${e} in the doctype printing`);

--- a/test/astro-prettier.test.mjs
+++ b/test/astro-prettier.test.mjs
@@ -70,7 +70,7 @@ test('can format an Astro file with frontmatter', Prettier, 'frontmatter');
 
 test('can format an Astro file with embedded JSX expressions', Prettier, 'embedded-expr');
 
-test.failing('can format an Astro file with a `<!DOCTYPE html>` + embedded JSX expressions', Prettier, 'doctype-with-embedded-expr');
+test('can format an Astro file with a `<!DOCTYPE html>` + embedded JSX expressions', Prettier, 'doctype-with-embedded-expr');
 
 test.failing('can format an Astro file with `<!DOCTYPE>` with extraneous attributes', Prettier, 'doctype-with-extra-attributes');
 


### PR DESCRIPTION
The reason why this bug occurred is a type error of empty element.  
This PR enables the user to format .astro files like this.  
```
---
import Color from "../components/Color.jsx";

let title = "My Site";

const colors = ["red", "yellow", "blue"];
---

<!DOCTYPE html>
<html lang="en">
  <head>
    <title>My site</title>
  </head>
  <body>
    <h1>{title}</h1>

    {"I'm some super long text and oh boy I sure do hope this formatter doesn't break me!"}

    {colors.map((color) => <div>
        <Color name={color} />
      </div>)}
  </body>
</html>

```
