### PR TITLE
Add support for formatting CodeFences w/in `<Markdown/>`

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -326,10 +326,13 @@ const print = (path, opts, print) => {
       return [`<!--`, getUnencodedText(node), `-->`];
     case 'CodeSpan':
       return getUnencodedText(node);
-    case 'CodeFence':
+    case 'CodeFence': {
       console.debug(node);
-      return getUnencodedText(node);
-    // We should use `node.metadata` to select a parser to embed with... something like return [node.metadata, hardline textToDoc(node.getMetadataLanguage()), hardline, `\`\`\``];
+      const lang = node.metadata.slice(3);
+      return [node.metadata, hardline, /** somehow call textToDoc(lang),  */ node.data, hardline, '```', hardline];
+
+      // We should use `node.metadata` to select a parser to embed with... something like return [node.metadata, hardline textToDoc(node.getMetadataLanguage()), hardline, `\`\`\``];
+    }
     default: {
       throw new Error(`Unhandled node type "${node.type}"!`);
     }

--- a/test/astro-prettier.test.mjs
+++ b/test/astro-prettier.test.mjs
@@ -83,6 +83,8 @@ test('can format an Astro file with a single style element', Prettier, 'single-s
 
 test('can format a basic Astro file with styles', Prettier, 'with-styles');
 
+test(`Can format an Astro file with attributes in the <style> tag`, Prettier, 'style-tag-attributes');
+
 test('can format a basic Astro file with SCSS styles', Prettier, 'with-scss');
 
 // TODO make this both test "does not fail on SASS & prints the raw source & a test that specifies whether we can actually format the SASS w/ an embed"
@@ -125,6 +127,4 @@ test.failing('Can format an Astro file with a HTML style prettier ignore comment
 
 test('Can format an Astro file with a JS style prettier ignore comment: https://prettier.io/docs/en/ignore.html', Prettier, 'prettier-ignore-js');
 
-test.failing(`Can format an Astro file with a template string`, Prettier, 'with-codespans');
-
-test(`Can format an Astro file with attributes in the <style> tag`, Prettier, 'style-tag-attributes');
+test.failing(`Can format an Astro file with a codespan inside <Markdown/>`, Prettier, 'with-codespans');

--- a/test/fixtures/out/with-codespans.astro
+++ b/test/fixtures/out/with-codespans.astro
@@ -7,11 +7,11 @@ import Markdown from "astro/components";
 
 <div>{`${helloWorld + space}too many template strings`}</div>
 <Markdown>
-`hello i am a codespan`
+  `hello i am a codespan`
 
-```js
-let story = "hello i am a codefence";
+  ```js
+  let story = "hello i am a codefence";
 
-story.length;
-```
+  story.length;
+  ```
 </Markdown>


### PR DESCRIPTION
## Changes

- Adds support for formatting Codefences `\`\`\`js` as opposed to naively printing them like we do today.

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->
