### PR TITLE
Add basic support for indented sass

### DIFF
--- a/.changeset/hungry-hotels-talk.md
+++ b/.changeset/hungry-hotels-talk.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Add basic support for indented sass

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   },
   "dependencies": {
     "@astrojs/parser": "^0.20.2",
-    "prettier": "^2.4.1"
+    "prettier": "^2.4.1",
+    "sass-formatter": "^0.7.2"
   },
   "devDependencies": {
     "@changesets/cli": "^2.16.0",

--- a/test/astro-prettier.test.mjs
+++ b/test/astro-prettier.test.mjs
@@ -88,7 +88,7 @@ test('can format a basic Astro file with SCSS styles', Prettier, 'with-scss');
 // TODO make this both test "does not fail on SASS & prints the raw source & a test that specifies whether we can actually format the SASS w/ an embed"
 test.todo('can return the basic SASS style block & remove extraneous whitespace - extremely naive support');
 
-test.failing('can format a basic Astro file with styles written in Indented SASS ', Prettier, 'with-indented-sass');
+test('can format a basic Astro file with styles written in Indented SASS', Prettier, 'with-indented-sass');
 
 test('can format an Astro file with frontmatter', Prettier, 'frontmatter');
 

--- a/test/fixtures/in/with-indented-sass.astro
+++ b/test/fixtures/in/with-indented-sass.astro
@@ -15,6 +15,133 @@
 
 
 <style lang="sass">
-h1
-    color: red
+
+
+$bg: #1E1E1E
+$text: #9cdcfe
+$shadow: #0002
+$fonts: monaco, Consolas, 'Lucida Console', monospace
+
+body
+  padding: 0
+    margin: 0
+   background: $bg
+   color: $text
+  font-family: $fonts
+  display: flex
+   flex-flow: column
+  height: 100vh
+
+.header
+     background: lighten($bg, 2.5)
+  box-shadow: 0 1px 4px $shadow
+    padding: 1rem 2rem
+  display: flex
+  align-content: center
+      align-items: center
+  justify-content: center
+
+.header-report-bug
+      position: absolute
+  right: 2rem
+
+.header-title
+  position: absolute
+  left: 2rem
+  font-size: 1.5rem
+
+.content
+  flex-grow: 1
+  display: grid
+      grid-template-rows: 2rem auto
+  gap: 1rem
+  margin: 1rem
+
+.center-text
+  text-align: center
+       > code
+    font-size: 1.1rem
+
+.editor-container
+  overflow: hidden
+
+a
+  color: $text
+  text-decoration: none
+  outline: none
+  transition: color 100ms ease
+
+     &:hover
+    color: darken($text, 40)
+
+  &:active
+    text-decoration: underline
+
+.loader-container
+background: $bg
+    position: absolute
+  top: 0
+      bottom: 0
+  right: 0
+  left: 0
+  transition: opacity 200ms ease
+
+.loader
+  position: fixed
+     border: 5px solid lighten($bg, 15)
+  border-top: 5px solid $text
+  border-radius: 50%
+  background: #0000
+       width: 25px
+  height: 25px
+  animation: spin 1s linear infinite
+       top: 50%
+  left: 50%
+  transform: translate(-50%, -50%)
+
+@keyframes spin
+  from
+    transform: rotate(0deg)
+
+      to
+    transform: rotate(360deg)
+
+@media screen and ( max-width: 700px )
+  .header
+    flex-direction: column
+       > *
+      margin: 0.3rem 0
+      .content
+    max-height: 80vh
+
+select
+  display: inline-block
+box-sizing: border-box
+  font: inherit
+     line-height: inherit
+  -webkit-appearance: none
+  -moz-appearance: none
+       -ms-appearance: none
+       appearance: none
+       outline: none
+  border: none
+
+  color: $text
+
+  border-radius: 5px
+
+  padding: 0.5em 2em 0.5em 0.5em
+
+     background-color: lighten($bg, 10)
+       background-repeat: no-repeat
+  background-image: linear-gradient(45deg, transparent 49.5%, currentColor 50%), linear-gradient(135deg, currentColor 49.5%, transparent 50%)
+        background-position: right 15px top 1em, right 10px top 1em
+  background-size: 5px 5px, 5px 5px
+
+  transition: background 200ms ease
+
+  cursor: pointer
+
+  &:hover
+    background-color: lighten($bg, 20)
 </style>

--- a/test/fixtures/in/with-scss.astro
+++ b/test/fixtures/in/with-scss.astro
@@ -21,4 +21,20 @@
                         background-color: white;
                 }
 }
+
+        nav {
+          ul {
+            margin: 0;
+            padding: 0;
+            list-style: none;
+          }
+
+          li { display: inline-block; }
+
+          a {
+            display: block;
+            padding: 6px 12px;
+            text-decoration: none;
+          }
+        }
 </style>

--- a/test/fixtures/out/with-indented-sass.astro
+++ b/test/fixtures/out/with-indented-sass.astro
@@ -12,6 +12,131 @@
 </html>
 
 <style lang="sass">
-  h1
-    color: red
+$bg: #1E1E1E
+$text: #9cdcfe
+$shadow: #0002
+$fonts: monaco, Consolas, 'Lucida Console', monospace
+
+body
+  padding: 0
+  margin: 0
+  background: $bg
+  color: $text
+  font-family: $fonts
+  display: flex
+  flex-flow: column
+  height: 100vh
+
+.header
+  background: lighten($bg, 2.5)
+  box-shadow: 0 1px 4px $shadow
+  padding: 1rem 2rem
+  display: flex
+  align-content: center
+  align-items: center
+  justify-content: center
+
+.header-report-bug
+  position: absolute
+  right: 2rem
+
+.header-title
+  position: absolute
+  left: 2rem
+  font-size: 1.5rem
+
+.content
+  flex-grow: 1
+  display: grid
+  grid-template-rows: 2rem auto
+  gap: 1rem
+  margin: 1rem
+
+.center-text
+  text-align: center
+  > code
+    font-size: 1.1rem
+
+.editor-container
+  overflow: hidden
+
+a
+  color: $text
+  text-decoration: none
+  outline: none
+  transition: color 100ms ease
+
+  &:hover
+    color: darken($text, 40)
+
+  &:active
+    text-decoration: underline
+
+.loader-container
+  background: $bg
+  position: absolute
+  top: 0
+  bottom: 0
+  right: 0
+  left: 0
+  transition: opacity 200ms ease
+
+.loader
+  position: fixed
+  border: 5px solid lighten($bg, 15)
+  border-top: 5px solid $text
+  border-radius: 50%
+  background: #0000
+  width: 25px
+  height: 25px
+  animation: spin 1s linear infinite
+  top: 50%
+  left: 50%
+  transform: translate(-50%, -50%)
+
+@keyframes spin
+  from
+    transform: rotate(0deg)
+
+  to
+    transform: rotate(360deg)
+
+@media screen and ( max-width: 700px )
+  .header
+    flex-direction: column
+    > *
+      margin: 0.3rem 0
+      .content
+        max-height: 80vh
+
+select
+  display: inline-block
+  box-sizing: border-box
+  font: inherit
+  line-height: inherit
+  -webkit-appearance: none
+  -moz-appearance: none
+  -ms-appearance: none
+  appearance: none
+  outline: none
+  border: none
+
+  color: $text
+
+  border-radius: 5px
+
+  padding: 0.5em 2em 0.5em 0.5em
+
+  background-color: lighten($bg, 10)
+  background-repeat: no-repeat
+  background-image: linear-gradient(45deg, transparent 49.5%, currentColor 50%), linear-gradient(135deg, currentColor 49.5%, transparent 50%)
+  background-position: right 15px top 1em, right 10px top 1em
+  background-size: 5px 5px, 5px 5px
+
+  transition: background 200ms ease
+
+  cursor: pointer
+
+  &:hover
+    background-color: lighten($bg, 20)
 </style>

--- a/test/fixtures/out/with-scss.astro
+++ b/test/fixtures/out/with-scss.astro
@@ -18,4 +18,22 @@
       background-color: white;
     }
   }
+
+  nav {
+    ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    li {
+      display: inline-block;
+    }
+
+    a {
+      display: block;
+      padding: 6px 12px;
+      text-decoration: none;
+    }
+  }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -325,10 +325,28 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@types/glob@^7.1.1":
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.4.tgz#ea59e21d2ee5c517914cb4bc8e4153b99e566672"
+  integrity sha512-w+LsMxKyYQm347Otw+IfBXOv9UWVjpHpCDdbBMt8Kz/xbvCYNjP+0qPh91Km3iKfSRLBB0P7fAMf0KHrPu+MyA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
+"@types/minimatch@*":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
+  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
+
+"@types/node@*":
+  version "16.10.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"
+  integrity sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==
 
 "@types/node@^12.7.1":
   version "12.20.16"
@@ -1035,6 +1053,28 @@ defer-to-connect@^1.0.1:
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
   integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
+del-cli@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/del-cli/-/del-cli-3.0.1.tgz#2d27ff260204b5104cadeda86f78f180a4ebe89a"
+  integrity sha512-BLHItGr82rUbHhjMu41d+vw9Md49i81jmZSV00HdTq4t+RTHywmEht/23mNFpUl2YeLYJZJyGz4rdlMAyOxNeg==
+  dependencies:
+    del "^5.1.0"
+    meow "^6.1.1"
+
+del@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/del/-/del-5.1.0.tgz#d9487c94e367410e6eff2925ee58c0c84a75b3a7"
+  integrity sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==
+  dependencies:
+    globby "^10.0.1"
+    graceful-fs "^4.2.2"
+    is-glob "^4.0.1"
+    is-path-cwd "^2.2.0"
+    is-path-inside "^3.0.1"
+    p-map "^3.0.0"
+    rimraf "^3.0.0"
+    slash "^3.0.0"
+
 del@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
@@ -1369,6 +1409,17 @@ fast-diff@^1.2.0:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
+fast-glob@^3.0.3:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
+  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-glob@^3.1.1:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.6.tgz#434dd9529845176ea049acc9343e8282765c6e1a"
@@ -1557,6 +1608,20 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
+globby@^10.0.1:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-10.0.2.tgz#277593e745acaa4646c3ab411289ec47a0392543"
+  integrity sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==
+  dependencies:
+    "@types/glob" "^7.1.1"
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.0.3"
+    glob "^7.1.3"
+    ignore "^5.1.1"
+    merge2 "^1.2.3"
+    slash "^3.0.0"
+
 globby@^11.0.0, globby@^11.0.1, globby@^11.0.2:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
@@ -1586,7 +1651,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.2.4:
+graceful-fs@^4.1.15, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
@@ -1812,7 +1877,7 @@ is-path-cwd@^2.2.0:
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-2.2.0.tgz#67d43b82664a7b5191fd9119127eb300048a9fdb"
   integrity sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==
 
-is-path-inside@^3.0.2:
+is-path-inside@^3.0.1, is-path-inside@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
@@ -2115,7 +2180,7 @@ mem@^8.0.0:
     map-age-cleaner "^0.1.3"
     mimic-fn "^3.1.0"
 
-meow@^6.0.0:
+meow@^6.0.0, meow@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-6.1.1.tgz#1ad64c4b76b2a24dfb2f635fddcadf320d251467"
   integrity sha512-3YffViIt2QWgTy6Pale5QpopX/IvU3LPL03jOTqp6pGj3VjesdO/U8CuHMKpnQr4shCNCM5fd5XFFvIIl6JBHg==
@@ -2132,7 +2197,7 @@ meow@^6.0.0:
     type-fest "^0.13.1"
     yargs-parser "^18.1.3"
 
-merge2@^1.3.0:
+merge2@^1.2.3, merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -2364,6 +2429,13 @@ p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
   integrity sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+
+p-map@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
+  integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
+  dependencies:
+    aggregate-error "^3.0.0"
 
 p-map@^4.0.0:
   version "4.0.0"
@@ -2722,7 +2794,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -2735,6 +2807,11 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
+
+s.color@0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/s.color/-/s.color-0.0.15.tgz#6b32cd22d8dba95703a5122ddede2020a1560186"
+  integrity sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==
 
 safe-buffer@~5.1.1:
   version "5.1.2"
@@ -2750,6 +2827,14 @@ safe-buffer@~5.2.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
+sass-formatter@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/sass-formatter/-/sass-formatter-0.7.2.tgz#bfac14c17dd7d3fb3967a5a80f5c34d27ed60daa"
+  integrity sha512-ZGpZC5bWJbv0tiu2glZeLhN85sg3wSySyHxhqov/HZX1/2coczLkY0HXIshrmRC7+G8qiFkeW8Ipl5mS54nl0w==
+  dependencies:
+    suf-log "^2.5.3"
+    suf-regex "^0.3.4"
 
 semver-diff@^3.1.1:
   version "3.1.1"
@@ -3001,6 +3086,20 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
+suf-log@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/suf-log/-/suf-log-2.5.3.tgz#0919a7fceea532a99b578c97814c4e335b2d64d1"
+  integrity sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==
+  dependencies:
+    s.color "0.0.15"
+
+suf-regex@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/suf-regex/-/suf-regex-0.3.4.tgz#8d1e0cafe1646755264895914cf44442a1202132"
+  integrity sha512-2Txjq2T4BrNKM53ACN8ZXzMulrL2ILDpTwWBy/bXX+gYALWB7pGkCVmCrj/TZrFgGWgmujdXoWmYfeyY2Ky4/g==
+  dependencies:
+    del-cli "^3.0.0"
 
 supertap@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #9
This is a temporarily fix until a SASS prettier plugin is made available.
The content of the style tag won't be indented.
The output will be like this:
```html
<style lang="sass">
$bg: #1E1E1E
$text: #9cdcfe
$shadow: #0002
$fonts: monaco, Consolas, 'Lucida Console', monospace

body
  padding: 0
  margin: 0
  background: $bg

.header
  background: lighten($bg, 2.5)
  box-shadow: 0 1px 4px $shadow
  justify-content: center
</style>
```
Instead for this:
```html
<style lang="sass">
  $bg: #1E1E1E
  $text: #9cdcfe
  $shadow: #0002
  $fonts: monaco, Consolas, 'Lucida Console', monospace

  body
    padding: 0
    margin: 0
    background: $bg

  .header
    background: lighten($bg, 2.5)
    box-shadow: 0 1px 4px $shadow
    justify-content: center
</style>
```