### PR TITLE
Update repo setup wrt (Typescript Refactor #38)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "ignorePatterns": ["test/**", "dist/**", "rollup.config.js"],
+  "ignorePatterns": ["test/fixtures/**", "dist/**", "rollup.config.js"],
   "plugins": ["prettier-doc"],
   "extends": ["eslint:recommended", "plugin:ava/recommended", "plugin:prettier-doc/recommended", "plugin:node/recommended"],
   "rules": {

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,8 +2,7 @@
 # Commands to start on workspace startup
 tasks:
   - init: yarn install
-    # no build step for us atm
-    # command: yarn build
+    command: yarn build
 vscode:
   extensions:
     # TODO Once astro is on [vsx](https://open-vsx.org/), we should be able to specify it as an extension as well!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Beta Prettier Plugin for [Astro](https://github.com/snowpackjs/astro) -- 🚧 Caution! May break your project 🚧
+# Beta Prettier Plugin for [Astro](https://github.com/snowpackjs/astro)
 
 ## Install [prettier-plugin-astro](https://www.npmjs.com/package/prettier-plugin-astro)
 
@@ -18,7 +18,8 @@ To get setup:
 
 1. `git clone git@github.com:snowpackjs/prettier-plugin-astro.git`
 1. `yarn`
-1. Run tests with `yarn test`
+1. `yarn build`
+1. Run tests with [`yarn test`](https://github.com/avajs/ava/tree/main/docs)
 1. Lint code with `yarn lint`
 1. Format code with `yarn format`
 1. Run `yarn changeset` to add your changes to the changelog on version bump.


### PR DESCRIPTION
## Changes

- Adds `yarn build` to contributing instructions + a link to the ava testing docs
- Adds `yarn build` to the `.gitpod.yml` setup so that prebuilds work again
- Adds `test/**` to the eslint so that we can lint for ava lint errors using `plugin:ava/recommended`

## Testing

<!-- How was this change tested? -->
<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## Docs

<!-- Was public documentation updated? -->
<!-- DON'T DELETE THIS SECTION! If no docs added, explain why (e.g. "bug fix only") -->

Marginally improved contributing docs - CONTRIBUTING.md should probably be a thing!
