### PR TITLE
Add new Astro option: 'allow shorthand'

### DIFF
--- a/.changeset/swift-scissors-swim.md
+++ b/.changeset/swift-scissors-swim.md
@@ -1,0 +1,5 @@
+---
+'prettier-plugin-astro': patch
+---
+
+Add Astro option: 'allow shorthand'

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,6 +6,7 @@ declare module 'prettier' {
 
 export interface PluginOptions {
   astroSortOrder: SortOrder;
+  astroAllowShorthand: boolean;
 }
 
 export const options: Record<keyof PluginOptions, SupportOption> = {
@@ -25,6 +26,13 @@ export const options: Record<keyof PluginOptions, SupportOption> = {
         description: 'styles | markup',
       },
     ],
+  },
+  astroAllowShorthand: {
+    since: '0.0.10',
+    category: 'Astro',
+    type: 'boolean',
+    default: true,
+    description: 'Enable/disable attribute shorthand if attribute name and expression are the same',
   },
 };
 

--- a/src/printer.ts
+++ b/src/printer.ts
@@ -371,7 +371,7 @@ function print(path: AstPath, opts: ParserOptions, print: printFn): Doc {
       return node.expression.name;
     }
     case 'Attribute': {
-      if (isOrCanBeConvertedToShorthand(node)) {
+      if (isOrCanBeConvertedToShorthand(node, opts)) {
         return [line, '{', node.name, '}'];
       } else {
         if (node.value === true) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,7 +53,8 @@ function isAttributeShorthand(node: attributeValue): node is [AttributeShorthand
 /**
  * True if node is of type `{a}` or `a={a}`
  */
-export function isOrCanBeConvertedToShorthand(node: AttributeNode): boolean {
+export function isOrCanBeConvertedToShorthand(node: AttributeNode, opts: ParserOptions): boolean {
+  if (!opts.astroAllowShorthand) return false;
   if (isAttributeShorthand(node.value)) {
     return true;
   }

--- a/test/astro-prettier.test.ts
+++ b/test/astro-prettier.test.ts
@@ -141,3 +141,9 @@ test('Can format an Astro file with prettier "astroSortOrder: markup | styles" o
 
 // astro option: astroSortOrder
 test('Can format an Astro file with prettier "astroSortOrder: styles | markup" option', Prettier, 'option-astro-sort-order-styles-markup');
+
+// astro option: astroAllowShorthand
+test('Can format an Astro file with prettier "astroAllowShorthand: true" option', Prettier, 'option-astro-allow-shorthand-true');
+
+// astro option: astroAllowShorthand
+test('Can format an Astro file with prettier "astroAllowShorthand: false" option', Prettier, 'option-astro-allow-shorthand-false');

--- a/test/fixtures/option-astro-allow-shorthand-false/input.astro
+++ b/test/fixtures/option-astro-allow-shorthand-false/input.astro
@@ -1,0 +1,4 @@
+---
+import Comp from "./comp.astro"
+---
+    <Comp options={options} />

--- a/test/fixtures/option-astro-allow-shorthand-false/options.json
+++ b/test/fixtures/option-astro-allow-shorthand-false/options.json
@@ -1,0 +1,3 @@
+{
+  "astroAllowShorthand": false
+}

--- a/test/fixtures/option-astro-allow-shorthand-false/output.astro
+++ b/test/fixtures/option-astro-allow-shorthand-false/output.astro
@@ -1,0 +1,5 @@
+---
+import Comp from "./comp.astro";
+---
+
+<Comp options={options} />

--- a/test/fixtures/option-astro-allow-shorthand-true/input.astro
+++ b/test/fixtures/option-astro-allow-shorthand-true/input.astro
@@ -1,0 +1,4 @@
+---
+import Comp from "./comp.astro"
+---
+    <Comp options={options} />

--- a/test/fixtures/option-astro-allow-shorthand-true/options.json
+++ b/test/fixtures/option-astro-allow-shorthand-true/options.json
@@ -1,0 +1,3 @@
+{
+  "astroAllowShorthand": true
+}

--- a/test/fixtures/option-astro-allow-shorthand-true/output.astro
+++ b/test/fixtures/option-astro-allow-shorthand-true/output.astro
@@ -1,0 +1,5 @@
+---
+import Comp from "./comp.astro";
+---
+
+<Comp {options} />


### PR DESCRIPTION
## Changes

Adds a new option (astroAllowShorthand) to disable automatic shorthand. It's enabled by default. Closes #39 

```astro
<!-- With the option set to false -->
<BaseLayout title={title}>
```

```astro
<!-- Default behavior  -->
<BaseLayout {title}>
```

## Testing

I added tests for each value of the new option.

## Docs